### PR TITLE
feat(db): adopt Supabase generated types across project

### DIFF
--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,0 +1,468 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      ai_drafts: {
+        Row: {
+          created_at: string
+          id: string
+          kind: Database["public"]["Enums"]["ai_draft_kind"]
+          payload: Json
+          thread_id: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          kind: Database["public"]["Enums"]["ai_draft_kind"]
+          payload: Json
+          thread_id?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          kind?: Database["public"]["Enums"]["ai_draft_kind"]
+          payload?: Json
+          thread_id?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      cards: {
+        Row: {
+          card_type: Database["public"]["Enums"]["card_type"]
+          content: Json
+          created_at: string
+          id: string
+          lesson_id: string
+          order_index: number
+          tags: string[]
+          title: string | null
+        }
+        Insert: {
+          card_type: Database["public"]["Enums"]["card_type"]
+          content: Json
+          created_at?: string
+          id?: string
+          lesson_id: string
+          order_index?: number
+          tags?: string[]
+          title?: string | null
+        }
+        Update: {
+          card_type?: Database["public"]["Enums"]["card_type"]
+          content?: Json
+          created_at?: string
+          id?: string
+          lesson_id?: string
+          order_index?: number
+          tags?: string[]
+          title?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cards_lesson_id_fkey"
+            columns: ["lesson_id"]
+            isOneToOne: false
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      courses: {
+        Row: {
+          category: string | null
+          created_at: string
+          description: string | null
+          id: string
+          owner_id: string
+          slug: string | null
+          status: Database["public"]["Enums"]["course_status"]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          id?: string
+          owner_id: string
+          slug?: string | null
+          status?: Database["public"]["Enums"]["course_status"]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          id?: string
+          owner_id?: string
+          slug?: string | null
+          status?: Database["public"]["Enums"]["course_status"]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      flags: {
+        Row: {
+          card_id: string
+          flagged_at: string
+          user_id: string
+        }
+        Insert: {
+          card_id: string
+          flagged_at?: string
+          user_id: string
+        }
+        Update: {
+          card_id?: string
+          flagged_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "flags_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lessons: {
+        Row: {
+          course_id: string
+          created_at: string
+          id: string
+          order_index: number
+          title: string
+        }
+        Insert: {
+          course_id: string
+          created_at?: string
+          id?: string
+          order_index?: number
+          title: string
+        }
+        Update: {
+          course_id?: string
+          created_at?: string
+          id?: string
+          order_index?: number
+          title?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lessons_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      notes: {
+        Row: {
+          card_id: string
+          text: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          card_id: string
+          text?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          card_id?: string
+          text?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notes_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          avatar_url: string | null
+          created_at: string
+          display_name: string | null
+          id: string
+          updated_at: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          created_at?: string
+          display_name?: string | null
+          id: string
+          updated_at?: string
+        }
+        Update: {
+          avatar_url?: string | null
+          created_at?: string
+          display_name?: string | null
+          id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      progress: {
+        Row: {
+          answer: Json | null
+          card_id: string
+          completed: boolean
+          completed_at: string | null
+          user_id: string
+        }
+        Insert: {
+          answer?: Json | null
+          card_id: string
+          completed?: boolean
+          completed_at?: string | null
+          user_id: string
+        }
+        Update: {
+          answer?: Json | null
+          card_id?: string
+          completed?: boolean
+          completed_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "progress_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      srs: {
+        Row: {
+          card_id: string
+          due: string
+          ease: number
+          interval: number
+          last_rating: Database["public"]["Enums"]["srs_rating"] | null
+          user_id: string
+        }
+        Insert: {
+          card_id: string
+          due: string
+          ease: number
+          interval?: number
+          last_rating?: Database["public"]["Enums"]["srs_rating"] | null
+          user_id: string
+        }
+        Update: {
+          card_id?: string
+          due?: string
+          ease?: number
+          interval?: number
+          last_rating?: Database["public"]["Enums"]["srs_rating"] | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "srs_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      ai_draft_kind: "outline" | "lesson-cards"
+      card_type: "text" | "quiz" | "fill-blank"
+      course_status: "draft" | "published"
+      srs_rating: "again" | "hard" | "good" | "easy"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      ai_draft_kind: ["outline", "lesson-cards"],
+      card_type: ["text", "quiz", "fill-blank"],
+      course_status: ["draft", "published"],
+      srs_rating: ["again", "hard", "good", "easy"],
+    },
+  },
+} as const
+

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -1,0 +1,13 @@
+import type { Database, TablesInsert } from "@/lib/database.types";
+
+export type TableName = keyof Database["public"]["Tables"];
+
+// 型の意図: id衝突時の部分更新（並び替えなど）で、Insert型の全プロパティを要求せず、
+// 実際に送る一部の列 + id だけを許可したい。しかし supabase-js は Insert 形状を要求するため
+// 最終的には安全な一括キャストが必要。そのキャスト地点をこの関数に集約する。
+export type UpsertByIdInput<T extends TableName> = Partial<TablesInsert<T>> & { id: string };
+
+export function asUpsertById<T extends TableName>(rows: UpsertByIdInput<T>[]): TablesInsert<T>[] {
+  return rows as unknown as TablesInsert<T>[];
+}
+

--- a/src/lib/db/mappers.ts
+++ b/src/lib/db/mappers.ts
@@ -1,0 +1,38 @@
+import type { Tables } from "@/lib/database.types";
+import type { Course, Lesson, Card } from "@/lib/types";
+
+export function mapCourse(r: Tables<"courses">): Course {
+  return {
+    id: r.id,
+    title: r.title,
+    description: r.description ?? undefined,
+    category: r.category ?? undefined,
+    status: r.status,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+export function mapLesson(r: Tables<"lessons">): Lesson {
+  return {
+    id: r.id,
+    courseId: r.course_id,
+    title: r.title,
+    orderIndex: r.order_index,
+    createdAt: r.created_at,
+  };
+}
+
+export function mapCard(r: Tables<"cards">): Card {
+  return {
+    id: r.id,
+    lessonId: r.lesson_id,
+    cardType: r.card_type,
+    title: r.title ?? null,
+    tags: r.tags,
+    content: r.content as Card["content"],
+    orderIndex: r.order_index,
+    createdAt: r.created_at,
+  };
+}
+

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/lib/database.types";
 
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -12,5 +13,5 @@ export function createClient() {
     throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable");
   }
   
-  return createBrowserClient(url, key);
+  return createBrowserClient<Database>(url, key);
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import type { Database } from "@/lib/database.types";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -17,7 +18,7 @@ export async function updateSession(request: NextRequest) {
     throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable");
   }
 
-  const supabase = createServerClient(
+  const supabase = createServerClient<Database>(
     url,
     key,
     {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { Database } from "@/lib/database.types";
 
 // Server-side Supabase client following the Next.js quickstart.
 // Uses public env vars and Next.js cookies to maintain the auth session.
@@ -12,7 +13,7 @@ export async function createClient() {
   // Next.js 15: cookies() is async in the official example
   const cookieStore = await cookies();
 
-  return createServerClient(supabaseUrl, supabaseKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 export type UUID = string;
+import type { Enums } from "@/lib/database.types";
 
-export type CourseStatus = 'draft' | 'published';
+export type CourseStatus = Enums<"course_status">;
 
 export type Course = {
   id: UUID;
@@ -20,7 +21,7 @@ export type Lesson = {
   createdAt: string; // ISO
 };
 
-export type CardType = 'text' | 'quiz' | 'fill-blank';
+export type CardType = Enums<"card_type">;
 
 export type TextCardContent = {
   body: string;
@@ -58,7 +59,7 @@ export type Progress = {
 };
 
 // Simple local SRS (Spaced Repetition) model
-export type SrsRating = "again" | "hard" | "good" | "easy";
+export type SrsRating = Enums<"srs_rating">;
 export type SrsEntry = {
   cardId: UUID;
   ease: number; // 1.3–3.0 range

--- a/src/server-actions/courses.ts
+++ b/src/server-actions/courses.ts
@@ -2,6 +2,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient, getCurrentUserId } from "@/lib/supabase/server";
 import type { UUID, Course } from "@/lib/types";
+import type { TablesInsert } from "@/lib/database.types";
 
 export async function createCourseAction(input: { title: string; description?: string; category?: string }): Promise<{ courseId: UUID }> {
   const supa = await createClient();
@@ -15,7 +16,7 @@ export async function createCourseAction(input: { title: string; description?: s
       description: input.description?.trim() || null,
       category: input.category?.trim() || null,
       status: "draft",
-    })
+    } satisfies TablesInsert<"courses">)
     .select("id")
     .single();
   if (error) throw error;


### PR DESCRIPTION
This PR adopts the Supabase generated types (src/lib/database.types.ts) as the single source of truth for all DB operations and tightens type-safety across the project.

Why
- Enforce type-safe DB access across server actions and queries
- Centralize row→domain mapping and reduce duplication
- Remove scattered type casts for partial upserts (reordering)

What changed
- Type clients with Database: lib/supabase/{server,client,middleware}.ts
- Replace handwritten Row types with Tables<>: lib/db/queries.ts
- Extract mappers: lib/db/mappers.ts
- Add upsert-by-id helper: lib/db/helpers.ts (asUpsertById, UpsertByIdInput)
- Align app enums to DB enums: lib/types.ts (CourseStatus, CardType, SrsRating)
- Use TablesInsert<> for inserts/upserts in server-actions (courses, lessons, cards, progress, ai)

Dev notes
- tsc: passing (no type errors)
- lint: only pre-existing warnings remain
- runtime: no env changes; requires NEXT_PUBLIC_SUPABASE_URL/ANON_KEY as before

Follow-ups (optional)
- Add Update helper types for patch patterns
- Add Zod validation for card content before insert/update
- Add unit tests for mappers.ts