### PR TITLE
fix: Server/Client境界の監査と修正

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,3 +1,4 @@
+"use client";
 import { createBrowserClient } from "@supabase/ssr";
 
 export function createClient() {


### PR DESCRIPTION
Supabase browser clientに必要な "use client" ディレクティブを追加

## 変更内容
- `src/lib/supabase/client.ts` に "use client" を追加

## 理由
`createBrowserClient`はSupabaseのブラウザ専用APIを使用するため、クライアントサイドでのみ実行されるべきです。

## 関連issue
Closes #6

Generated with [Claude Code](https://claude.ai/code)